### PR TITLE
Updates for TLS in container

### DIFF
--- a/main-api.tf
+++ b/main-api.tf
@@ -239,6 +239,9 @@ data "template_file" "task_def_api" {
     SERVICE_INTEGRATION_TOKEN = "${random_id.service_integration_token.hex}"
     LOG_LEVEL                 = "${var.log_level}"
     DISABLE_TLS               = "${var.disable_tls}"
+    CERT_DOMAIN_NAME          = "${var.subdomain_api}.${var.cloudflare_domain}"
+    CLOUDFLARE_AUTH_EMAIL     = "${var.cloudflare_email}"
+    CLOUDFLARE_AUTH_KEY       = "${var.cloudflare_token}"
   }
 }
 

--- a/main-api.tf
+++ b/main-api.tf
@@ -15,7 +15,7 @@ module "ecr" {
 resource "aws_alb_target_group" "tg" {
   name                 = "${replace("tg-${var.app_name}-${data.terraform_remote_state.common.app_env}", "/(.{0,32})(.*)/", "$1")}"
   port                 = "3000"
-  protocol             = "HTTP"
+  protocol             = "${var.disable_tls == "true" ? "HTTP" : "HTTPS"}"
   vpc_id               = "${data.terraform_remote_state.common.vpc_id}"
   deregistration_delay = "30"
 
@@ -92,7 +92,7 @@ module "rds" {
 }
 
 /*
- * Create S3 bucket and credentials to store files in the bucket for request attachments
+ * Create user to interact with S3, SES, and DynamoDB (for CertMagic)
  */
 resource "aws_iam_user" "wecarry" {
   name = "${var.app_name}-${data.terraform_remote_state.common.app_env}"
@@ -117,6 +117,20 @@ resource "aws_iam_user_policy" "wecarry" {
         "ses:SendRawEmail"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "DynamoDB",
+      "Effect": "Allow",
+      "Action":[
+        "dynamodb:ConditionCheck",
+        "dynamodb:DeleteItem",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:UpdateItem"
+      ],
+      "Resource": "arn:aws:dynamodb:::table/CertMagic"
     }
   ]
 }
@@ -192,10 +206,10 @@ data "template_file" "task_def_api" {
     DATABASE_URL              = "postgres://${var.db_user}:${random_id.db_password.hex}@${module.rds.address}:5432/${var.db_database}?sslmode=disable"
     UI_URL                    = "${var.ui_url}"
     HOST                      = "https://${var.subdomain_api}.${var.cloudflare_domain}"
-    AWS_REGION                = "${var.aws_region}"
+    AWS_DEFAULT_REGION        = "${var.aws_region}"
     AWS_S3_BUCKET             = "${var.aws_s3_bucket}"
-    AWS_S3_ACCESS_KEY_ID      = "${aws_iam_access_key.attachments.id}"
-    AWS_S3_SECRET_ACCESS_KEY  = "${aws_iam_access_key.attachments.secret}"
+    AWS_ACCESS_KEY_ID         = "${aws_iam_access_key.attachments.id}"
+    AWS_SECRET_ACCESS_KEY     = "${aws_iam_access_key.attachments.secret}"
     AZURE_AD_KEY              = "${var.azure_ad_key}"
     AZURE_AD_SECRET           = "${var.azure_ad_secret}"
     AZURE_AD_TENANT           = "${var.azure_ad_tenant}"
@@ -224,6 +238,7 @@ data "template_file" "task_def_api" {
     ROLLBAR_TOKEN             = "${var.rollbar_token}"
     SERVICE_INTEGRATION_TOKEN = "${random_id.service_integration_token.hex}"
     LOG_LEVEL                 = "${var.log_level}"
+    DISABLE_TLS               = "${var.disable_tls}"
   }
 }
 

--- a/task-def-api.json
+++ b/task-def-api.json
@@ -38,20 +38,20 @@
         "value": "${HOST}"
       },
       {
-        "name": "AWS_REGION",
-        "value": "${AWS_REGION}"
+        "name": "AWS_DEFAULT_REGION",
+        "value": "${AWS_DEFAULT_REGION}"
       },
       {
         "name": "AWS_S3_BUCKET",
         "value": "${AWS_S3_BUCKET}"
       },
       {
-        "name": "AWS_S3_ACCESS_KEY_ID",
-        "value": "${AWS_S3_ACCESS_KEY_ID}"
+        "name": "AWS_ACCESS_KEY_ID",
+        "value": "${AWS_ACCESS_KEY_ID}"
       },
       {
-        "name": "AWS_S3_SECRET_ACCESS_KEY",
-        "value": "${AWS_S3_SECRET_ACCESS_KEY}"
+        "name": "AWS_SECRET_ACCESS_KEY",
+        "value": "${AWS_SECRET_ACCESS_KEY}"
       },
       {
         "name": "AZURE_AD_KEY",
@@ -160,6 +160,10 @@
       {
         "name": "LOG_LEVEL",
         "value": "${LOG_LEVEL}"
+      },
+      {
+        "name": "DISABLE_TLS",
+        "value": "${DISABLE_TLS}"
       }
     ],
     "ulimits": null,

--- a/task-def-api.json
+++ b/task-def-api.json
@@ -164,6 +164,18 @@
       {
         "name": "DISABLE_TLS",
         "value": "${DISABLE_TLS}"
+      },
+      {
+        "name": "CERT_DOMAIN_NAME",
+        "value": "${CERT_DOMAIN_NAME}"
+      },
+      {
+        "name": "CLOUDFLARE_AUTH_EMAIL",
+        "value": "${CLOUDFLARE_AUTH_EMAIL}"
+      },
+      {
+        "name": "CLOUDFLARE_AUTH_KEY",
+        "value": "${CLOUDFLARE_AUTH_KEY}"
       }
     ],
     "ulimits": null,

--- a/vars.tf
+++ b/vars.tf
@@ -34,15 +34,15 @@ variable "cloudflare_token" {}
 variable "cloudflare_domain" {}
 variable "email_from_address" {}
 variable "email_service" {}
-variable "facebook_key" {default=""}
-variable "facebook_secret" {default=""}
+variable "facebook_key" { default = "" }
+variable "facebook_secret" { default = "" }
 variable "go_env" {}
-variable "google_key" {default=""}
-variable "google_secret" {default=""}
-variable "linked_in_key" {default=""}
-variable "linked_in_secret" {default=""}
-variable "microsoft_key" {default=""}
-variable "microsoft_secret" {default=""}
+variable "google_key" { default = "" }
+variable "google_secret" { default = "" }
+variable "linked_in_key" { default = "" }
+variable "linked_in_secret" { default = "" }
+variable "microsoft_key" { default = "" }
+variable "microsoft_secret" { default = "" }
 
 variable "mailchimp_api_base_url" {
   default = "https://us4.api.mailchimp.com/3.0"
@@ -61,8 +61,8 @@ variable "subdomain_ui_dns_name" {
 }
 
 
-variable "twitter_key" {default=""}
-variable "twitter_secret" {default=""}
+variable "twitter_key" { default = "" }
+variable "twitter_secret" { default = "" }
 variable "tf_remote_common" {}
 variable "ui_bucket_name" {}
 
@@ -124,4 +124,10 @@ variable "ui_aliases" {
 
 variable "log_level" {
   description = "Level below which log messages are silenced"
+}
+
+variable "disable_tls" {
+  description = "Whether or not to disable HTTPS/TLS"
+  type        = "string"
+  default     = "false"
 }


### PR DESCRIPTION
Also refactored AWS user to use single set of credentials instead of different credentials for each service.

Corresponding PR in `wecarry-api` to adapt to these changes: https://github.com/silinternational/wecarry-api/pull/296