### PR TITLE
disconnect "common" remote due to Terraform version conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.tfstate
 *.tfstate.backup
 .terraform/
+tfc-remote.tf
+*.tfvars

--- a/main-api.tf
+++ b/main-api.tf
@@ -3,10 +3,10 @@
  */
 module "ecr" {
   source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.5.0"
-  repo_name           = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
-  ecsInstanceRole_arn = data.terraform_remote_state.common.outputs.ecsInstanceRole_arn
-  ecsServiceRole_arn  = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
-  cd_user_arn         = data.terraform_remote_state.common.outputs.codeship_arn
+  repo_name           = "${var.app_name}-${var.common_app_env}"
+  ecsInstanceRole_arn = var.common_ecsInstanceRole_arn
+  ecsServiceRole_arn  = var.common_ecsServiceRole_arn
+  cd_user_arn         = var.common_codeship_arn
 }
 
 /*
@@ -14,13 +14,13 @@ module "ecr" {
  */
 resource "aws_alb_target_group" "tg" {
   name = replace(
-    "tg-${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}",
+    "tg-${var.app_name}-${var.common_app_env}",
     "/(.{0,32})(.*)/",
     "$1",
   )
   port                 = "3000"
   protocol             = var.disable_tls == "true" ? "HTTP" : "HTTPS"
-  vpc_id               = data.terraform_remote_state.common.outputs.vpc_id
+  vpc_id               = var.common_vpc_id
   deregistration_delay = "30"
 
   stickiness {
@@ -38,7 +38,7 @@ resource "aws_alb_target_group" "tg" {
  * Create listener rule for hostname routing to new target group
  */
 resource "aws_alb_listener_rule" "tg" {
-  listener_arn = data.terraform_remote_state.common.outputs.alb_https_listener_arn
+  listener_arn = var.common_alb_https_listener_arn
   priority     = "719"
 
   action {
@@ -57,12 +57,12 @@ resource "aws_alb_listener_rule" "tg" {
  * Create cloudwatch log group for app logs
  */
 resource "aws_cloudwatch_log_group" "wecarry" {
-  name              = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
+  name              = "${var.app_name}-${var.common_app_env}"
   retention_in_days = 14
 
   tags = {
     app_name = var.app_name
-    app_env  = data.terraform_remote_state.common.outputs.app_env
+    app_env  = var.common_app_env
   }
 }
 
@@ -83,16 +83,16 @@ resource "random_id" "service_integration_token" {
 module "rds" {
   source              = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=3.5.0"
   app_name            = var.app_name
-  app_env             = "${data.terraform_remote_state.common.outputs.app_env}-tf"
+  app_env             = "${var.common_app_env}-tf"
   engine              = "postgres"
   instance_class      = var.db_instance_class
   storage_encrypted   = var.db_storage_encrypted
   db_name             = var.db_database
   db_root_user        = var.db_user
   db_root_pass        = random_id.db_password.hex
-  subnet_group_name   = data.terraform_remote_state.common.outputs.db_subnet_group_name
-  availability_zone   = data.terraform_remote_state.common.outputs.aws_zones[0]
-  security_groups     = [data.terraform_remote_state.common.outputs.vpc_default_sg_id]
+  subnet_group_name   = var.common_db_subnet_group_name
+  availability_zone   = var.common_aws_zones[0]
+  security_groups     = [var.common_vpc_default_sg_id]
   deletion_protection = var.db_deletion_protection
 }
 
@@ -100,7 +100,7 @@ module "rds" {
  * Create user to interact with S3, SES, and DynamoDB (for CertMagic)
  */
 resource "aws_iam_user" "wecarry" {
-  name = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
+  name = "${var.app_name}-${var.common_app_env}"
 }
 
 resource "aws_iam_access_key" "attachments" {
@@ -160,7 +160,7 @@ resource "aws_s3_bucket" "attachments" {
   tags = {
     Name     = var.aws_s3_bucket
     app_name = var.app_name
-    app_env  = data.terraform_remote_state.common.outputs.app_env
+    app_env  = var.common_app_env
   }
 }
 
@@ -168,7 +168,7 @@ resource "aws_s3_bucket" "attachments" {
  * Create Lambda user
  */
 resource "aws_iam_user" "wecarry_lambdas" {
-  name = "app-${data.terraform_remote_state.common.outputs.app_env}-${var.app_name}-lambdas"
+  name = "app-${var.common_app_env}-${var.app_name}-lambdas"
 }
 
 resource "aws_iam_access_key" "lambdas" {
@@ -179,13 +179,13 @@ data "template_file" "serverless_policy" {
   template = file("${path.module}/serverless-policy.json")
 
   vars = {
-    app_env    = data.terraform_remote_state.common.outputs.app_env
+    app_env    = var.common_app_env
     aws_region = var.aws_region
   }
 }
 
 resource "aws_iam_policy" "wecarry_lambdas" {
-  name        = "app-${data.terraform_remote_state.common.outputs.app_env}-${var.app_name}-lambdas-deploy"
+  name        = "app-${var.common_app_env}-${var.app_name}-lambdas-deploy"
   description = "WeCarry user for Serverless Lambdas deployment"
 
   policy = data.template_file.serverless_policy.rendered
@@ -208,7 +208,7 @@ data "template_file" "task_def_api" {
     memory                    = var.memory
     docker_image              = module.ecr.repo_url
     docker_tag                = var.docker_tag
-    APP_ENV                   = data.terraform_remote_state.common.outputs.app_env
+    APP_ENV                   = var.common_app_env
     DATABASE_URL              = "postgres://${var.db_user}:${random_id.db_password.hex}@${module.rds.address}:5432/${var.db_database}?sslmode=disable"
     UI_URL                    = var.ui_url
     HOST                      = "https://${var.subdomain_api}.${var.cloudflare_domain}"
@@ -240,7 +240,7 @@ data "template_file" "task_def_api" {
     TWITTER_SECRET            = var.twitter_secret
     log_group                 = aws_cloudwatch_log_group.wecarry.name
     region                    = var.aws_region
-    log_stream_prefix         = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
+    log_stream_prefix         = "${var.app_name}-${var.common_app_env}"
     ROLLBAR_TOKEN             = var.rollbar_token
     SERVICE_INTEGRATION_TOKEN = random_id.service_integration_token.hex
     LOG_LEVEL                 = var.log_level
@@ -256,15 +256,15 @@ data "template_file" "task_def_api" {
  */
 module "ecsapi" {
   source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.5.0"
-  cluster_id         = data.terraform_remote_state.common.outputs.ecs_cluster_id
+  cluster_id         = var.common_ecs_cluster_id
   service_name       = "${var.app_name}-api"
-  service_env        = data.terraform_remote_state.common.outputs.app_env
+  service_env        = var.common_app_env
   container_def_json = data.template_file.task_def_api.rendered
   desired_count      = var.desired_count
   tg_arn             = aws_alb_target_group.tg.arn
   lb_container_name  = "buffalo"
   lb_container_port  = "3000"
-  ecsServiceRole_arn = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
+  ecsServiceRole_arn = var.common_ecsServiceRole_arn
 }
 
 /*
@@ -273,7 +273,7 @@ module "ecsapi" {
 resource "cloudflare_record" "dns" {
   domain  = var.cloudflare_domain
   name    = var.subdomain_api
-  value   = data.terraform_remote_state.common.outputs.alb_dns_name
+  value   = var.common_alb_dns_name
   type    = "CNAME"
   proxied = true
 }
@@ -283,13 +283,13 @@ resource "cloudflare_record" "dns" {
  */
 resource "aws_alb_target_group" "adminer" {
   name = replace(
-    "tg-${var.app_name}-adminer-${data.terraform_remote_state.common.outputs.app_env}",
+    "tg-${var.app_name}-adminer-${var.common_app_env}",
     "/(.{0,32})(.*)/",
     "$1",
   )
   port                 = "8080"
   protocol             = "HTTP"
-  vpc_id               = data.terraform_remote_state.common.outputs.vpc_id
+  vpc_id               = var.common_vpc_id
   deregistration_delay = "30"
 
   stickiness {
@@ -306,7 +306,7 @@ resource "aws_alb_target_group" "adminer" {
  * Create listener rule for hostname routing to new target group
  */
 resource "aws_alb_listener_rule" "adminer" {
-  listener_arn = data.terraform_remote_state.common.outputs.alb_https_listener_arn
+  listener_arn = var.common_alb_https_listener_arn
   priority     = "720"
 
   action {
@@ -341,15 +341,15 @@ data "template_file" "task_def_adminer" {
  */
 module "ecsadminer" {
   source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=3.5.0"
-  cluster_id         = data.terraform_remote_state.common.outputs.ecs_cluster_id
+  cluster_id         = var.common_ecs_cluster_id
   service_name       = "${var.app_name}-adminer"
-  service_env        = data.terraform_remote_state.common.outputs.app_env
+  service_env        = var.common_app_env
   container_def_json = data.template_file.task_def_adminer.rendered
   desired_count      = var.enable_adminer
   tg_arn             = aws_alb_target_group.adminer.arn
   lb_container_name  = "adminer"
   lb_container_port  = "8080"
-  ecsServiceRole_arn = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
+  ecsServiceRole_arn = var.common_ecsServiceRole_arn
 }
 
 /*
@@ -359,7 +359,7 @@ resource "cloudflare_record" "adminer" {
   count   = var.enable_adminer
   domain  = var.cloudflare_domain
   name    = "${var.subdomain_api}-adminer"
-  value   = data.terraform_remote_state.common.outputs.alb_dns_name
+  value   = var.common_alb_dns_name
   type    = "CNAME"
   proxied = true
 }

--- a/main-ui.tf
+++ b/main-ui.tf
@@ -9,7 +9,7 @@ module "uisite" {
   cf_default_ttl      = "0"
   origin_path         = "/public"
   s3_origin_id        = "s3-origin"
-  deployment_user_arn = data.terraform_remote_state.common.outputs.codeship_arn
+  deployment_user_arn = var.common_codeship_arn
 }
 
 // Create DNS CNAME record on Cloudflare for UI

--- a/remote.tf
+++ b/remote.tf
@@ -1,8 +1,8 @@
-data "terraform_remote_state" "common" {
-  backend = "atlas"
-
-  config = {
-    name = var.tf_remote_common
-  }
-}
+//data "terraform_remote_state" "common" {
+//  backend = "atlas"
+//
+//  config = {
+//    name = var.tf_remote_common
+//  }
+//}
 

--- a/vars.tf
+++ b/vars.tf
@@ -200,3 +200,17 @@ variable "disable_tls" {
   default     = "false"
 }
 
+// the following variables are a temporary replacement for the "common" remote state
+variable "common_app_env" {}
+variable "common_ecsInstanceRole_arn" {}
+variable "common_ecsServiceRole_arn" {}
+variable "common_codeship_arn" {}
+variable "common_vpc_id" {}
+variable "common_alb_https_listener_arn" {}
+variable "common_db_subnet_group_name" {}
+variable "common_vpc_default_sg_id" {}
+variable "common_ecs_cluster_id" {}
+variable "common_alb_dns_name" {}
+variable "common_aws_zones" {
+  type = list(string)
+}


### PR DESCRIPTION
The remote has a TF 0.13 state which cannot be used by this workspace configured for TF 0.12.