### PR TITLE
add env to redis cluster name

### DIFF
--- a/main-api.tf
+++ b/main-api.tf
@@ -3,7 +3,7 @@
  */
 module "ecr" {
   source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.6.2"
-  repo_name           = "local.app_name_and_env"
+  repo_name           = local.app_name_and_env
   ecsInstanceRole_arn = data.terraform_remote_state.common.outputs.ecsInstanceRole_arn
   ecsServiceRole_arn  = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
   cd_user_arn         = data.terraform_remote_state.common.outputs.codeship_arn
@@ -14,7 +14,7 @@ module "ecr" {
  */
 resource "aws_alb_target_group" "tg" {
   name = replace(
-    "tg-local.app_name_and_env",
+    "tg-${local.app_name_and_env}",
     "/(.{0,32})(.*)/",
     "$1",
   )
@@ -57,7 +57,7 @@ resource "aws_alb_listener_rule" "tg" {
  * Create cloudwatch log group for app logs
  */
 resource "aws_cloudwatch_log_group" "wecarry" {
-  name              = "local.app_name_and_env"
+  name              = local.app_name_and_env
   retention_in_days = 14
 
   tags = {
@@ -101,7 +101,7 @@ module "rds11" {
  * Create user to interact with S3, SES, and DynamoDB (for CertMagic)
  */
 resource "aws_iam_user" "wecarry" {
-  name = "local.app_name_and_env"
+  name = local.app_name_and_env
 }
 
 resource "aws_iam_access_key" "attachments" {
@@ -241,7 +241,7 @@ data "template_file" "task_def_api" {
     TWITTER_SECRET            = var.twitter_secret
     log_group                 = aws_cloudwatch_log_group.wecarry.name
     region                    = var.aws_region
-    log_stream_prefix         = "local.app_name_and_env"
+    log_stream_prefix         = local.app_name_and_env
     ROLLBAR_TOKEN             = var.rollbar_token
     SERVICE_INTEGRATION_TOKEN = random_id.service_integration_token.hex
     LOG_LEVEL                 = var.log_level

--- a/main-api.tf
+++ b/main-api.tf
@@ -3,7 +3,7 @@
  */
 module "ecr" {
   source              = "github.com/silinternational/terraform-modules//aws/ecr?ref=3.6.2"
-  repo_name           = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
+  repo_name           = "local.app_name_and_env"
   ecsInstanceRole_arn = data.terraform_remote_state.common.outputs.ecsInstanceRole_arn
   ecsServiceRole_arn  = data.terraform_remote_state.common.outputs.ecsServiceRole_arn
   cd_user_arn         = data.terraform_remote_state.common.outputs.codeship_arn
@@ -14,7 +14,7 @@ module "ecr" {
  */
 resource "aws_alb_target_group" "tg" {
   name = replace(
-    "tg-${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}",
+    "tg-local.app_name_and_env",
     "/(.{0,32})(.*)/",
     "$1",
   )
@@ -57,7 +57,7 @@ resource "aws_alb_listener_rule" "tg" {
  * Create cloudwatch log group for app logs
  */
 resource "aws_cloudwatch_log_group" "wecarry" {
-  name              = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
+  name              = "local.app_name_and_env"
   retention_in_days = 14
 
   tags = {
@@ -101,7 +101,7 @@ module "rds11" {
  * Create user to interact with S3, SES, and DynamoDB (for CertMagic)
  */
 resource "aws_iam_user" "wecarry" {
-  name = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
+  name = "local.app_name_and_env"
 }
 
 resource "aws_iam_access_key" "attachments" {
@@ -169,7 +169,7 @@ resource "aws_s3_bucket" "attachments" {
  * Create Lambda user
  */
 resource "aws_iam_user" "wecarry_lambdas" {
-  name = "app-${data.terraform_remote_state.common.outputs.app_env}-${var.app_name}-lambdas"
+  name = "app-${local.app_name_and_env}-lambdas"
 }
 
 resource "aws_iam_access_key" "lambdas" {
@@ -186,7 +186,7 @@ data "template_file" "serverless_policy" {
 }
 
 resource "aws_iam_policy" "wecarry_lambdas" {
-  name        = "app-${data.terraform_remote_state.common.outputs.app_env}-${var.app_name}-lambdas-deploy"
+  name        = "app-${local.app_name_and_env}-lambdas-deploy"
   description = "WeCarry user for Serverless Lambdas deployment"
 
   policy = data.template_file.serverless_policy.rendered
@@ -241,7 +241,7 @@ data "template_file" "task_def_api" {
     TWITTER_SECRET            = var.twitter_secret
     log_group                 = aws_cloudwatch_log_group.wecarry.name
     region                    = var.aws_region
-    log_stream_prefix         = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
+    log_stream_prefix         = "local.app_name_and_env"
     ROLLBAR_TOKEN             = var.rollbar_token
     SERVICE_INTEGRATION_TOKEN = random_id.service_integration_token.hex
     LOG_LEVEL                 = var.log_level
@@ -376,11 +376,15 @@ resource "cloudflare_record" "adminer" {
 
 module "redis" {
   source             = "github.com/silinternational/terraform-modules//aws/elasticache/redis?ref=3.6.2"
-  cluster_id         = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}-redis"
+  cluster_id         = "${local.app_name_and_env}-redis"
   security_group_ids = [data.terraform_remote_state.common.outputs.vpc_default_sg_id]
-  subnet_group_name  = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}-redis"
+  subnet_group_name  = "${local.app_name_and_env}-redis"
   subnet_ids         = data.terraform_remote_state.common.outputs.private_subnet_ids
   availability_zones = data.terraform_remote_state.common.outputs.aws_zones
   app_name           = var.app_name
   app_env            = data.terraform_remote_state.common.outputs.app_env
+}
+
+locals {
+  app_name_and_env = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
 }

--- a/main-api.tf
+++ b/main-api.tf
@@ -376,9 +376,9 @@ resource "cloudflare_record" "adminer" {
 
 module "redis" {
   source             = "github.com/silinternational/terraform-modules//aws/elasticache/redis?ref=3.6.2"
-  cluster_id         = "${var.app_name}-redis"
+  cluster_id         = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}-redis"
   security_group_ids = [data.terraform_remote_state.common.outputs.vpc_default_sg_id]
-  subnet_group_name  = "${var.app_name}-redis-subnet"
+  subnet_group_name  = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}-redis"
   subnet_ids         = data.terraform_remote_state.common.outputs.private_subnet_ids
   availability_zones = data.terraform_remote_state.common.outputs.aws_zones
   app_name           = var.app_name


### PR DESCRIPTION
Also renames the lambda and lambda user to consistently use app_name+app_env rather than app_env+app_name