### PR TITLE
remove subdomain_ui variable for clarity and to fix ui_url output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,15 +7,15 @@ output "db_password" {
 }
 
 output "ui_bucket" {
-  value = "${var.subdomain_ui}.${var.cloudflare_domain}"
+  value = cloudflare_record.ui.hostname
 }
 
 output "ui_url" {
-  value = "https://${var.subdomain_ui}.${var.cloudflare_domain}"
+  value = "https://${cloudflare_record.ui.hostname}"
 }
 
 output "api_url" {
-  value = "https://${var.subdomain_api}.${var.cloudflare_domain}"
+  value = "https://${cloudflare_record.dns.hostname}"
 }
 
 output "serverless-access-key-id" {

--- a/vars.tf
+++ b/vars.tf
@@ -126,7 +126,7 @@ variable "session_secret" {
 }
 
 variable "subdomain_ui_dns_name" {
-  description = "Used as value sent to cloudflare for dns record, separate var from subdomain_ui so that in prod we can pass @"
+  description = "Used as value sent to cloudflare for dns record, accepts @ for root domain"
 }
 
 variable "twitter_key" {
@@ -145,10 +145,6 @@ variable "ui_bucket_name" {
 
 variable "subdomain_api" {
   default = "api"
-}
-
-variable "subdomain_ui" {
-  default = "my"
 }
 
 variable "docker_tag" {


### PR DESCRIPTION
### Fixed
- Fixed `ui_url` output. On production, it was showing as `https://.wecarry.app`. (Note the extra dot.)
### Removed
- Removed `subdomain_ui` variable.